### PR TITLE
Percent parser works incorrect without float part

### DIFF
--- a/js/core/utils/number_parser_generator.js
+++ b/js/core/utils/number_parser_generator.js
@@ -31,7 +31,7 @@ function getIntegerPartRegExp(formatString) {
             "([1-9]\\d{0," + (firstGroupSize - 1) + "},)(\\d{" + firstGroupSize + "},)*\\d{" +
             lastGroupSize + "}|([1-9]\\d{0," + (lastGroupSize - 1 - requiredDigitCount) + "})?");
     } else {
-        result = result.replace(/#+/g, "([1-9]\\d*)?" + (requiredDigitCount ? "" : "|[0]"));
+        result = result.replace(/#+/g, "(([1-9]\\d*)?" + (requiredDigitCount ? ")" : "|[0])"));
     }
     return result;
 }

--- a/testing/tests/DevExpress.core/utils.format.tests.js
+++ b/testing/tests/DevExpress.core/utils.format.tests.js
@@ -138,6 +138,17 @@ QUnit.test("percent format parsing", function(assert) {
     assert.strictEqual(parser("-10%"), null, "negative value without float part should be incorrect");
 });
 
+QUnit.test("percent format parsing without float part", function(assert) {
+    var parser = generateNumberParser("#%");
+
+    assert.strictEqual(parser("1%"), 0.01, "integer with 1 digit");
+    assert.strictEqual(parser("15%"), 0.15, "integer with several digits");
+    assert.strictEqual(parser("10.0%"), null, "float is incorrect");
+    assert.strictEqual(parser("0%"), 0, "zero");
+    assert.strictEqual(parser("-0%"), -0, "negative zero");
+    assert.strictEqual(parser("-10%"), -0.1, "negative integer");
+});
+
 
 QUnit.module("number formatter");
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
